### PR TITLE
Update strategy.js

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -101,7 +101,7 @@ JwtStrategy.prototype.authenticate = function(req, options) {
             self.fail(secretOrKeyError)
         } else {
             // Verify the JWT
-            JwtStrategy.JwtVerifier(token, secretOrKey, self._verifOpts, function(jwt_err, payload) {
+            JwtStrategy.JwtVerifier(token(req), secretOrKey, self._verifOpts, function(jwt_err, payload) {
                 if (jwt_err) {
                     return self.fail(jwt_err);
                 } else {


### PR DESCRIPTION
Fix issue of jwt retrieve function (named token ) being passed to     JwtStrategy.JwtVerifier function instead of being called on the request to  retrieve / produce  the token to be verified